### PR TITLE
feat: Update static.yml to produce main-site-content artifact

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,19 +1,17 @@
-# Workflow for deploying PR previews to GitHub Pages subdirectory
+# .github/workflows/preview.yml
 name: Deploy PR Preview to Pages
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened] # Trigger on PR creation, updates, and reopening
+    types: [opened, synchronize, reopened]
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-# Also needs pull-request write permission to comment on PRs
 permissions:
   contents: read
   pages: write
   id-token: write
   pull-requests: write
+  actions: read # Required to download artifacts from other workflow runs
 
-# Allow only one concurrent deployment for each PR, cancelling older runs for the same PR.
 concurrency:
   group: "pages-pr-${{ github.event.number }}"
   cancel-in-progress: true
@@ -21,73 +19,75 @@ concurrency:
 jobs:
   deploy-preview:
     environment:
-      name: github-pages-pr-preview # Using a slightly different environment name for clarity
-      url: ${{ steps.deployment.outputs.page_url }}
+      name: github-pages-pr-preview
+      url: ${{ steps.deployment.outputs.page_url }} # This should be the PR preview URL
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Determine Preview Path
+      - name: Determine Preview Subdirectory Path
         id: path_vars
         run: |
           if [ -z "${{ github.event.number }}" ]; then
             echo "Error: PR number (github.event.number) is not available."
             exit 1
           fi
-          echo "preview_path=pr-preview/${{ github.event.number }}" >> $GITHUB_ENV
-          # Base URL path for potential <base> tag, includes leading and trailing slash for safety
-          echo "base_url_path=/pr-preview/${{ github.event.number }}/" >> $GITHUB_ENV
-          echo "Preview path will be: pr-preview/${{ github.event.number }}"
+          echo "preview_subdir=pr-preview/${{ github.event.number }}" >> $GITHUB_ENV
+          echo "Preview subdirectory will be: pr-preview/${{ github.event.number }}"
 
-      - name: Validate Preview Path
+      - name: Validate Preview Subdirectory Path # Keep this check
         run: |
-          if [ -z "${{ env.preview_path }}" ]; then
-            echo "Error: env.preview_path is empty. This would cause a root deployment."
+          if [ -z "${{ env.preview_subdir }}" ]; then
+            echo "Error: env.preview_subdir is empty. This is unexpected."
             exit 1
-          else
-            echo "env.preview_path is set to: ${{ env.preview_path }}"
           fi
 
-      # Optional: Adjust base href for PR previews if assets don't load correctly.
-      # Start without this, as relative paths should work.
-      # - name: Adjust base href for PR previews
-      #   run: |
-      #     # Ensure the path in sed command is correctly escaped if base_url_path contains special characters
-      #     # Using a different delimiter for sed in case path contains slashes
-      #     sed -i "s%<head>%<head><base href='${{ github.server_url }}/${{ github.repository }}${{ env.base_url_path }}' />%" index.html
-      #   working-directory: . # Assuming index.html is in the root
+      # Removed the old "Assemble Combined Artifact" manual git clone step.
+      # New steps for checking out PR code and downloading main site artifact follow.
 
-      - name: Prepare Artifact for Upload
-        run: |
-          echo "Creating directory: artifact_to_upload/${{ env.preview_path }}"
-          mkdir -p artifact_to_upload/${{ env.preview_path }}
-          echo "Copying files to artifact_to_upload/${{ env.preview_path }}/"
-          # Copy all files and directories, excluding .git, .github, and the artifact dir itself
-          # Using rsync for more control and to easily exclude
-          rsync -av --progress . artifact_to_upload/${{ env.preview_path }}/ --exclude .git --exclude .github --exclude artifact_to_upload
-          echo "Finished copying files."
-        # This moves all files into the target directory.
+      - name: Checkout PR code (current branch)
+        uses: actions/checkout@v4
+        with:
+          path: 'pr_code' # Checkout PR code into a specific subdirectory
 
-      - name: List Artifact Contents
+      - name: Download latest 'main-site-content' artifact
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: static.yml # Name of the workflow that produces the artifact (or its ID)
+          name: main-site-content # Name of the artifact to download
+          branch: main # Branch from which the workflow run was triggered
+          path: combined_site_artifact # Destination directory for the downloaded artifact
+                                     # The artifact's contents will be placed here.
+          github_token: ${{ secrets.GITHUB_TOKEN }} # Token for authentication
+          # Optional: specify run_id if you need a very specific run, otherwise latest successful is usually fine.
+          # Optional: set 'if_no_artifact_found' to 'fail' (default), 'warn', or 'ignore'.
+
+      - name: Copy PR content into artifact subdirectory
         run: |
-          echo "Listing contents of artifact_to_upload directory:"
-          ls -R artifact_to_upload
+          ARTIFACT_ROOT="combined_site_artifact" # Should already exist from download step
+          PR_CODE_PATH="pr_code" # Source of PR files
+          PR_DEST_SUBDIR="${{ env.preview_subdir }}" # e.g., pr-preview/123
+          
+          echo "Copying PR code from $PR_CODE_PATH to $ARTIFACT_ROOT/$PR_DEST_SUBDIR/"
+          mkdir -p "$ARTIFACT_ROOT/$PR_DEST_SUBDIR"
+          # Copy everything from pr_code checkout, excluding its .git if it exists
+          rsync -av --progress $PR_CODE_PATH/ "$ARTIFACT_ROOT/$PR_DEST_SUBDIR/" --exclude .git
+
+          echo "Listing contents of $ARTIFACT_ROOT directory after combining:"
+          ls -R $ARTIFACT_ROOT
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Upload artifact
+      - name: Upload artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'artifact_to_upload' # Upload the parent directory which contains the pr-preview/NUMBER structure
+          path: 'combined_site_artifact'
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
 
       - name: Post PR Comment with Preview Link (Find Existing)
-        if: success() # Run only if previous steps were successful
+        if: success()
         uses: peter-evans/find-comment@v3
         id: fc
         with:
@@ -96,13 +96,13 @@ jobs:
           body-includes: '🚀 PR Preview available at:'
 
       - name: Create or Update PR Comment
-        if: success() # Run only if previous steps were successful
+        if: success()
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: |
-            🚀 PR Preview available at: https://grandtrain.ca/pr-preview/${{ github.event.number }}/
-            (Debug - Raw page_url from deployment: ${{ steps.deployment.outputs.page_url }})
+            🚀 PR Preview available at: https://grandtrain.ca/${{ env.preview_subdir }}/
+            (Base content from latest 'main' branch deployment)
             Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           edit-mode: replace

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,13 +31,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+
+      - name: Archive production deployment
+        uses: actions/upload-artifact@v4
         with:
-          # Upload entire repository
+          name: main-site-content # Name of the artifact
+          path: | # Paths to include in the artifact
+            ./
+            !./.git # Exclude .git directory
+            !./.github # Exclude .github directory (if not needed for site content)
+          retention-days: 7 # Optional: Keep artifacts for a week
+
+      - name: Setup Pages # For actual deployment to GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact for GitHub Pages deployment
+        uses: actions/upload-pages-artifact@v3 # This is for GitHub Pages
+        with:
+          # Upload entire repository (or specific built site if there was a build step)
           path: '.'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The `static.yml` workflow has been updated to include a step that archives the production site content (everything in the root directory, excluding .git and .github) and uploads it as a named workflow artifact: `main-site-content`.

This artifact will be used by the `preview.yml` workflow to obtain the base content for PR previews, ensuring consistency with the main site deployment.

The existing functionality of `static.yml` to deploy the main branch to GitHub Pages remains unchanged.